### PR TITLE
Added support for Unity 2021.2.0b

### DIFF
--- a/UndoPro/UndoProManager.cs
+++ b/UndoPro/UndoProManager.cs
@@ -84,7 +84,12 @@ namespace UndoPro
 			// Fetch Reflection members for Undo interaction
 			Assembly UnityEditorAsssembly = Assembly.GetAssembly (typeof(UnityEditor.Editor));
 			Type undoType = UnityEditorAsssembly.GetType ("UnityEditor.Undo");
+			
+#if UNITY_2021_2_OR_NEWER
+			MethodInfo getRecordsInternal = undoType.GetMethod ("GetTimelineRecordsInternal", BindingFlags.NonPublic | BindingFlags.Static);
+#else 
 			MethodInfo getRecordsInternal = undoType.GetMethod ("GetRecordsInternal", BindingFlags.NonPublic | BindingFlags.Static);
+#endif
 			getRecordsInternalDelegate = (Action<object, object>)Delegate.CreateDelegate (typeof(Action<object, object>), getRecordsInternal);
 
 			// Create dummy object


### PR DESCRIPTION
Unity has moved their 'GetRecordsInternal' method to 'GetTimelineRecordsInternal'.

I just wrote a simple snippet to ensure it still works in the latest version.